### PR TITLE
Fix steamline tags for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: default
     steps:
       - uses: actions/checkout@v2
 
@@ -26,7 +26,7 @@ jobs:
 
   lint:
     name: lint
-    runs-on: self-hosted
+    runs-on: default
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   test:
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
 
@@ -25,6 +26,7 @@ jobs:
 
   lint:
     name: lint
+    runs-on: self-hosted
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2


### PR DESCRIPTION
Due to a mistaken understanding of what runs-on actually would do if removed we have managed to break our pipelines by removing the runs-on: default. This PR reverts the changes to remove runs-on: default and runs-on: self-hosted and makes sure that we only use runs-on: default.